### PR TITLE
88- candidatos marcar como destacado

### DIFF
--- a/src/app/candidatos-destacados/candidatos-destacados.page.ts
+++ b/src/app/candidatos-destacados/candidatos-destacados.page.ts
@@ -4,6 +4,8 @@ import { EgresadosService } from '../shared/services/egresados.service';
 import { Egresado } from '../shared/interfaces/egresado.interface';
 import { EgresadoDetailsPage } from '../egresado-details/egresado-details.page';
 import { egresadosFilters } from '../shared/interfaces/egresadosFilters.interface';
+import { RouterExtService } from '../shared/services/RouterExt.service';
+import { APP_ROUTES } from '../shared/constants';
 
 @Component({
   selector: 'app-egresados',
@@ -23,14 +25,23 @@ export class CandidatosDestacadosPage implements OnInit {
   constructor(
     private egresadosService: EgresadosService,
     private modalCtrl: ModalController,
+    private routerExtService: RouterExtService,
   ) {}
 
+  ionViewWillEnter() {
+    const previousUrl = this.routerExtService.getPreviousUrl();
+    if (previousUrl === APP_ROUTES.tabs.destacados) {
+      this.egresados = [];
+      this.loadEgresados();
+    }
+  }
+
   ngOnInit() {
-    this.loading = true;
     this.loadEgresados();
   }
 
   async loadEgresados() {
+    this.loading = true;
     this.egresadosService.getEgresadosCandidatos(this.pageNumber, this.searchQuery)
       .subscribe((egresados) => {
         this.egresados = egresados;
@@ -68,6 +79,7 @@ export class CandidatosDestacadosPage implements OnInit {
       component: EgresadoDetailsPage,
       componentProps: {
         egresadoId: egresadoId,
+        candidatosMode: true,
       }
     });
 
@@ -77,6 +89,10 @@ export class CandidatosDestacadosPage implements OnInit {
     
     if (role === 'confirm') {
       console.log('✨ Modal egresadoDetail closed. ->', data);
+
+      if (data) {
+        this.loadEgresados();
+      }
     } 
   }
 }

--- a/src/app/configuracion/configuracion.page.html
+++ b/src/app/configuracion/configuracion.page.html
@@ -24,7 +24,7 @@
         <ion-row style="height: 100%;" class="ion-justify-content-center" *ngIf="egresado">
           <ion-thumbnail class="egresados-detail-thumnail ">
             <ion-img class="avatar-img"
-              src="{{egresado.profilePicUrl || 'assets/img/profile/profile-icon.webp'}}"></ion-img>
+              src="{{(egresado && egresado.profilePicUrl) || 'assets/img/profile/profile-icon.webp'}}"></ion-img>
           </ion-thumbnail>
         </ion-row>
         <ion-row class="ion-justify-content-center" style="margin-top: 15px;">

--- a/src/app/configuracion/configuracion.page.ts
+++ b/src/app/configuracion/configuracion.page.ts
@@ -14,10 +14,9 @@ import { Egresado } from '../shared/interfaces/egresado.interface';
 })
 export class ConfiguracionPage {
   loggedInRol: ROLES;
-  loggedUserId: number;
+  loggedEgresadoId: number;
   usuario: Usuario;
   egresado: Egresado;
-  userId: number;
 
   constructor(
     private authService: AuthService,
@@ -29,20 +28,23 @@ export class ConfiguracionPage {
   async ionViewWillEnter() {
     const loggedInUser = await this.storage.get('loggedInUserId');
 
-    this.loggedUserId = loggedInUser;
     if (loggedInUser) {
       this.authService
         .getUsuario(loggedInUser)
         .subscribe((usuario: Usuario) => {
           this.usuario = usuario;
-          this.userId = usuario.egresadoId;
+          this.loggedEgresadoId = usuario.egresadoId;
+
           this.authService.setLoggedUserRole(usuario.rolUsuario[0]);
           this.storage.set('loggedUserRole', usuario.rolUsuario[0]);
-          this.egresadosService
-            .getEgresadoById(this.userId)
-            .subscribe((egresado: Egresado) => {
-              this.egresado = egresado;
-            });
+
+          if (this.loggedEgresadoId) {
+            this.egresadosService
+              .getEgresadoById(this.loggedEgresadoId)
+              .subscribe((egresado: Egresado) => {
+                this.egresado = egresado;
+              });
+          }
         });
     } else {
       this.router.navigate(['/tabs/login']);
@@ -50,7 +52,7 @@ export class ConfiguracionPage {
   }
 
   goToEgresadoEdit() {
-    this.router.navigate(['/egresado-edit', this.loggedUserId]);
+    this.router.navigate(['/egresado-edit', this.loggedEgresadoId]);
   }
 
   getRole() {
@@ -64,6 +66,7 @@ export class ConfiguracionPage {
   }
 
   async logout() {
+    this.egresado = null;
     this.authService.logout();
     this.router.navigate(['/tabs/egresados']);
   }

--- a/src/app/destacados/destacados.page.html
+++ b/src/app/destacados/destacados.page.html
@@ -18,12 +18,12 @@
     </ion-toolbar>
   </ion-header>
   <app-loader [isLoading]="loading"></app-loader>
-  <div class="row" *ngIf="!(egresados.length > 0)">
+  <div class="row" *ngIf="!(egresados && egresados.length > 0)">
     <div class="col">
       <div class="text-center">
           <ion-text style="text-align: center; display: block;" color="medium" >No hay resultados disponibles</ion-text>
       </div>
     </div>
   </div>
-  <app-egresados-list *ngIf="egresados.length > 0" [egresados]="egresados" (pageNumber)="setPageNumber($event)" (egresadoClicked)="openEgresadoDetailsModal($event)"></app-egresados-list>
+  <app-egresados-list *ngIf="egresados && egresados.length > 0" [egresados]="egresados" (pageNumber)="setPageNumber($event)" (egresadoClicked)="openEgresadoDetailsModal($event)"></app-egresados-list>
 </ion-content>

--- a/src/app/destacados/destacados.page.ts
+++ b/src/app/destacados/destacados.page.ts
@@ -2,12 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { EgresadosService } from '../shared/services/egresados.service';
 import { Egresado } from '../shared/interfaces/egresado.interface';
 import { HelperService } from '../shared/services/helper.service';
-import { LOADING_TIMEOUT } from '../shared/constants';
+import { APP_ROUTES } from '../shared/constants';
 import { ModalController } from '@ionic/angular';
 import { EgresadoDetailsPage } from '../egresado-details/egresado-details.page';
 import { EgresadosFiltersComponent } from '../shared/components/egresados-filters/egresados-filters.component';
 import { egresadosFilters } from '../shared/interfaces/egresadosFilters.interface';
 import { environment } from 'src/environments/environment';
+import { RouterExtService } from '../shared/services/RouterExt.service';
 @Component({
   selector: 'app-destacados',
   templateUrl: './destacados.page.html',
@@ -25,10 +26,19 @@ export class DestacadosPage implements OnInit {
     private egresadosService: EgresadosService,
     public helperService: HelperService,
     private modalCtrl: ModalController,
+    private routerExtService: RouterExtService
   ) {}
 
   ngOnInit() {
     this.loadEgresados();
+  }
+
+  ionViewWillEnter() {
+    const previousUrl = this.routerExtService.getPreviousUrl();
+    if (previousUrl === APP_ROUTES.tabs.candidatos) {
+      this.egresados = [];
+      this.loadEgresados();
+    }
   }
   
   loadEgresados() {
@@ -78,6 +88,10 @@ export class DestacadosPage implements OnInit {
     
     if (role === 'confirm') {
       console.log('✨ Modal egresadoDetail closed. ->', data);
+      if (data) {
+        this.egresados = [];
+        this.loadEgresados();
+      }
     } 
   }
 

--- a/src/app/egresado-details/egresado-details.module.ts
+++ b/src/app/egresado-details/egresado-details.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { IonicModule } from '@ionic/angular';
 
@@ -18,6 +18,7 @@ import { NgxMaskDirective, NgxMaskPipe, provideNgxMask } from 'ngx-mask';
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     IonicModule,
     EgresadoDetailsPageRoutingModule,
     SharedModule,

--- a/src/app/egresado-details/egresado-details.page.html
+++ b/src/app/egresado-details/egresado-details.page.html
@@ -63,42 +63,70 @@
             </ion-text>
           </ion-row>
         </ion-row>
+        <!-- Si el usuario es administrador puede ver esta sección -->
         <ion-row *ngIf="userIsAdmin" style="width: 100%;" class="ion-justify-content-center ion-align-items-center padding-top-10">
           <ion-row *ngIf="!egresado.Activo" style="width: 80%;" class="ion-justify-content-center ion-align-items-center padding-top-10 padding-bottom-10">
               <p style="color: #CE5A67">
                 Este egresado se encuentra desactivado, no será visible en la listas de egresado.
               </p>
           </ion-row>
-          <ion-row class="ion-justify-content-between" style="min-width: 170px;">
-            <ion-button expand="block" color="light" *ngIf="egresado.Activo" (click)="setEgresadoStatus(false)">
+          <ion-row class="ion-justify-content-center" style="min-width: 170px;">
+            <ion-button expand="block" color="light" *ngIf="egresado.Activo" (click)="toggleEgresadoActiveStatus(false)">
               Desactivar Perfil
               <ion-icon name="eye-off-outline" slot="end"></ion-icon>
             </ion-button>
-            <ion-button expand="block" color="light" *ngIf="!egresado.Activo" (click)="setEgresadoStatus(true)">
+            <ion-button expand="block" color="light" *ngIf="!egresado.Activo" (click)="toggleEgresadoActiveStatus(true)">
               Activar Perfil
               <ion-icon name="eye-outline" slot="end"></ion-icon>
             </ion-button>
-            <!-- <ion-text>
-              <span class="info-text-color egresados-list-egresado-direccion">
-                {{this.helperService.getAge(this.egresado.FechaNac)}} años
-              </span>
-            </ion-text>
-            <ion-text class="egresados-list-egresado-direccion info-text-width" *ngFor="let direccion of egresado.direccionEgresado">
-              <ion-row class="ion-align-items-center">
-                <ion-icon name="location-sharp"></ion-icon>
-                <span *ngIf="direccion">
-                  {{direccion.provincia}}
-                </span>
-              </ion-row>
-            </ion-text> -->
-            <!-- <ion-text class="egresados-list-egresado-direccion info-text-width" *ngIf="egresado.direccionEgresado && egresado.direccionEgresado.length === 0">
-              <ion-row class="ion-align-items-center">
-                <ion-icon name="location-sharp"></ion-icon>
-                <span>
-                 Sin especificar
-                </span>
-              </ion-row>
-            </ion-text> -->
+
+            <!-- Descripción de por qué el egresado es destacado -->
+            <ng-container>
+              <ion-button expand="block" color="light" *ngIf="!egresado.destacado && !marcarDestacadoMode && !egresado.fueDestacado" (click)="toggleMarcarDestacadoMode(true)">
+                Marcar como Destacado
+                <ion-icon name="star" class="destacado-color" slot="end"></ion-icon>
+              </ion-button>
+              <ion-button expand="block" color="light" *ngIf="egresado.destacado" (click)="desmarcarDestacadoConfirmation()">
+                Remover de Destacados
+                <ion-icon name="star-outline" class="destacado-color" slot="end"></ion-icon>
+              </ion-button>
+            
+              <ion-card [ngStyle]="{'--ion-background-color': '#fff' }" *ngIf="marcarDestacadoMode">
+                <ion-card-content> 
+                  <form
+                    class="ion-margin"
+                    [formGroup]="marcarDestacadoForm">
+                    <ion-row>
+                      <ion-textarea
+                        style="min-height: 150px;"
+                        type="text"
+                        fill="solid"
+                        label="Descripción Destacado"
+                        labelPlacement="floating"
+                        helperText="Ingresa una Descripción de Destacado"
+                        errorText="Información Inválida"
+                        formControlName="descripcionDestacado"
+                        [maxlength]="descripcionDestacadoLength"
+                        (keyup)="onDescripcionDestacadoKeyUp($event)">
+                      </ion-textarea>
+                      <div style="display: flex; flex-direction: column; justify-content: end; width: 100%;">
+                        <span class="muted contador-de-letras">{{contador}} / {{descripcionDestacadoLength}}</span>
+                      </div>
+                    </ion-row>
+                    <ion-row class="ion-justify-content-center" style="margin-top: 10px;">
+                      <ion-button color="light" class="ion-text-wrap" (click)="toggleMarcarDestacadoMode()">
+                        Cancelar
+                      </ion-button>
+                      <ion-button color="light" class="ion-text-wrap" (click)="marcarComoDestacado()">
+                        Aceptar
+                        <ion-icon name="star" class="destacado-color" slot="end"></ion-icon>
+                      </ion-button>
+                    </ion-row>
+                  </form>
+                </ion-card-content>
+              </ion-card>
+            </ng-container>
+
           </ion-row>
         </ion-row>
         <ion-row *ngIf="egresado.destacado" style="width: 100%;" class="ion-justify-content-center ion-align-items-center padding-top-15">
@@ -110,7 +138,7 @@
     </ion-grid>
 
     <!-- Card Destacado -->
-    <ion-card [ngStyle]="egresado.destacado ? { '--ion-background-color': '#fff' } : null" *ngIf="egresado.destacado">
+    <ion-card [ngStyle]="egresado.destacado ? { '--ion-background-color': '#fff' } : null" *ngIf="egresado.destacado && !marcarDestacadoMode">
       <ion-card-header>
         <ion-card-title class="title-color">
           <div style="display: flex; flex-direction: row; align-items: center;">
@@ -119,7 +147,16 @@
           </div>
         </ion-card-title>
       </ion-card-header>
-      <ion-card-content> {{egresado.descripcionDestacado}} </ion-card-content>
+      <ion-card-content> 
+        {{egresado.descripcionDestacado}}
+
+        <ion-row style="width: 100; margin-top: 5px;" class="ion-justify-content-center">
+          <ion-button color="light" *ngIf="userIsAdmin" (click)="toggleMarcarDestacadoMode()">
+            Editar Descripción
+            <ion-icon name="create-outline"  class="destacado-color"></ion-icon>
+          </ion-button>
+        </ion-row>
+      </ion-card-content>
     </ion-card>
    
     <!--Card About-->

--- a/src/app/egresado-details/egresado-details.page.scss
+++ b/src/app/egresado-details/egresado-details.page.scss
@@ -74,6 +74,7 @@ h3 {
 }
 
 .destacado-color {
+  margin-left: 5px;
   color: #f1dd38;
 }
 
@@ -114,3 +115,10 @@ h3 {
 .white-background {
   --ion-background-color: '#fff' 
 } 
+
+.contador-de-letras {
+  font-size: 14px;
+  display: flex;
+  justify-content: right;
+  bottom: 15px;
+}

--- a/src/app/egresado-details/egresado-details.page.ts
+++ b/src/app/egresado-details/egresado-details.page.ts
@@ -2,10 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { Egresado } from '../shared/interfaces/egresado.interface';
 import { EgresadosService } from '../shared/services/egresados.service';
-import { LOADING_TIMEOUT } from '../shared/constants';
-import { ModalController, ToastController } from '@ionic/angular';
+import { ABOUT_TEXTAREA_LENGTH, LOADING_TIMEOUT } from '../shared/constants';
+import { AlertController, ModalController, ToastController } from '@ionic/angular';
 import { HelperService } from '../shared/services/helper.service';
 import { StorageService } from '../shared/services/storage.service';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-egresado-details',
@@ -14,11 +15,20 @@ import { StorageService } from '../shared/services/storage.service';
 })
 export class EgresadoDetailsPage implements OnInit {
   @Input() egresadoId: number;
+  @Input() candidatosMode: boolean;
 
+  contador: number = 0;
+  descripcionDestacadoLength = ABOUT_TEXTAREA_LENGTH;
   egresado: Egresado = {};
   loading: boolean = true;
   userIsAdmin: boolean = false;
   egresadoChanged: boolean = false;
+  marcarDestacadoMode: boolean = false;
+  marcarDestacadoModeFromBtn: boolean = false;
+
+  marcarDestacadoForm: FormGroup = this.fb.group({
+    descripcionDestacado: ['', [Validators.maxLength(ABOUT_TEXTAREA_LENGTH)]]
+  });
 
   constructor(
     private location: Location,
@@ -27,6 +37,8 @@ export class EgresadoDetailsPage implements OnInit {
     private modalCtrl: ModalController,
     private storage: StorageService,
     private toastCtrl: ToastController,
+    private fb: FormBuilder,
+    private alertController: AlertController
   ) { }
 
   async ngOnInit() {
@@ -40,6 +52,8 @@ export class EgresadoDetailsPage implements OnInit {
       this.egresadoService.getEgresadoById(this.egresadoId)
         .subscribe((egresado: Egresado) => {
           this.egresado = egresado;
+
+          this.loadMarcarDestacadoForm();
           console.log('egresado-details: Egresado Cargado -> ', this.egresado);
 
           setTimeout(() => {
@@ -49,27 +63,124 @@ export class EgresadoDetailsPage implements OnInit {
     }
   }
 
+  loadMarcarDestacadoForm() {
+    this.marcarDestacadoForm.patchValue({ descripcionDestacado: this.egresado.descripcionDestacado });
+  }
+
   onBackButtonClick(): void {
     this.location.back();
   }
 
-  setEgresadoStatus(status: boolean) {
-    this.egresadoService.updateEgresadoStatus(this.egresadoId, status)
+  toggleEgresadoActiveStatus(status: boolean) {
+    this.egresadoService.updateEgresadoStatus(this.egresadoId, { Activo: status })
       .subscribe(async (egresado) => {
-        console.log('🚀 ~ file: egresado-details.page.ts:66 ~ EgresadoDetailsPage ~ .subscribe ~ egresado:', egresado);
         this.egresado.Activo = egresado.Activo;
-        
-        const toastMsg = 'El Perfil de este Egresado fue';
-        const toast = await this.toastCtrl.create({
-          message: status ? `${toastMsg} Activado.` : `${toastMsg} Desactivado.`,
-          duration: 1500,
-          position: 'bottom',
-        });
-    
-        await toast.present();
-
+        const toastMsg = `El Perfil de este Egresado fue` + (status ? ` Activado.` : ` Desactivado.`);
+        this.statusChangedToast(toastMsg);
         this.egresadoChanged = true;
       });
+  }
+
+  toggleEgresadoDestacado(status: boolean) {
+    const egresadoUpdate = {
+      destacado: status,
+      fueDestacado: true,
+      descripcionDestacado: this.marcarDestacadoForm.get('descripcionDestacado').value
+    }
+
+    this.egresadoService.updateEgresadoStatus(this.egresadoId, egresadoUpdate)
+      .subscribe(async (egresado) => {
+        this.egresado.destacado = egresado.destacado;
+        this.egresado.descripcionDestacado = egresado.descripcionDestacado;
+        this.egresado.fueDestacado = egresado.fueDestacado;
+
+        this.marcarDestacadoMode = false;
+        this.marcarDestacadoModeFromBtn = false;
+        const toastMsg = `El Perfil de este Egresado fue ` + (status ? ` marcado como Destacado.` : ` removido de Destacados.`);
+        this.statusChangedToast(toastMsg);
+        this.egresadoChanged = true;
+      });
+  }
+
+  toggleMarcarDestacadoMode(fromDedicatedButton: boolean = false) {
+    if (fromDedicatedButton) {
+      this.marcarDestacadoModeFromBtn = !this.marcarDestacadoModeFromBtn
+    }
+
+    this.marcarDestacadoMode = !this.marcarDestacadoMode;
+  }
+
+  async marcarComoDestacado(showConfirmation: boolean = false) {
+    if (this.marcarDestacadoModeFromBtn) {
+      const alert = await this.alertController.create({
+        header: '¿Estás seguro de marcar este egresado como Destacado?',
+        subHeader: 'Solo podrás marcar un egresado una vez, un egresado no podrá ser Destacado dos veces.',
+        message: '',
+        buttons: [
+          {
+            text: 'Cancelar',
+            role: 'cancel',
+            handler: () => {
+              console.log('✨ Alerta Cancelada')
+            },
+          },
+          {
+            text: 'OK',
+            role: 'Confirmar',
+            handler: () => {
+              console.log('✨ Alerta Aceptada')
+              this.toggleEgresadoDestacado(true);
+            },
+          },
+        ],
+      });
+      await alert.present();
+    } else {
+      this.egresadoService.updateEgresadoStatus(this.egresadoId, { descripcionDestacado: this.marcarDestacadoForm.get('descripcionDestacado').value})
+        .subscribe(async (egresado) => {
+          this.egresado.descripcionDestacado = egresado.descripcionDestacado;
+          this.marcarDestacadoMode = false;
+          this.egresadoChanged = true;
+        });
+    }
+
+  }
+
+  async desmarcarDestacadoConfirmation() {
+    const alert = await this.alertController.create({
+      header: '¿Estás seguro de remover el estado de Destacado de este egresado?',
+      subHeader: 'Una vez remuevas el status de Destacado, este egresado no podrá ser Destacado de nuevo.',
+      message: '',
+      buttons: [
+        {
+          text: 'Cancelar',
+          role: 'cancel',
+          handler: () => {
+            console.log('✨ Alerta Cancelada')
+          },
+        },
+        {
+          text: 'OK',
+          role: 'Confirmar',
+          handler: () => {
+            console.log('✨ Alerta Aceptada')
+            this.toggleEgresadoDestacado(false);
+          },
+        },
+      ],
+    });
+
+    await alert.present();
+  }
+
+  async statusChangedToast(msg: string) {
+    const toast = await this.toastCtrl.create({
+      message: msg,
+      duration: 1500,
+      position: 'top',
+    });
+
+    await toast.present();
   }
 
   confirm() {
@@ -79,6 +190,10 @@ export class EgresadoDetailsPage implements OnInit {
     }
     
     this.modalCtrl.dismiss(data, 'confirm');
+  }
+
+  onDescripcionDestacadoKeyUp(event?: any) {
+    this.contador = event.target.value.length;
   }
 
 }

--- a/src/app/egresado-edit/egresado-edit.page.ts
+++ b/src/app/egresado-edit/egresado-edit.page.ts
@@ -17,7 +17,7 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '../shared/shared.module';
 import { IonicSelectableComponent } from 'ionic-selectable';
 import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
-import { ABOUTLENGHT } from '../shared/constants';
+import { ABOUT_TEXTAREA_LENGTH } from '../shared/constants';
 
 @Component({
   selector: 'app-egresado-edit',
@@ -42,7 +42,7 @@ export class EgresadoEditPage implements OnInit {
   provincias: Provincia[];
   selectedProfilePic: any;
   contador: number = 0;
-  maxLenght: number = ABOUTLENGHT;
+  maxLenght: number = ABOUT_TEXTAREA_LENGTH;
 
   egresadoForm: FormGroup = this.fb.group({
     PrimerNombre: ['', [Validators.required, Validators.maxLength(100)]],
@@ -608,6 +608,7 @@ export class EgresadoEditPage implements OnInit {
       this.egresadoForm.patchValue({ profilePicUrl: this.selectedProfilePic.dataUrl});
     }
   }
+  
   onKey(event?: any) {
     this.contador = event.target.value.length;
   }

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -10,7 +10,7 @@ export const LOADING_TIMEOUT = 0;
 
 export const EXPCOOKIE = 30
 
-export const ABOUTLENGHT = 500
+export const ABOUT_TEXTAREA_LENGTH = 500
 
 export const TIPO_TITULO = [
   {
@@ -42,4 +42,11 @@ export const TIPO_TITULO = [
 export enum ROLES {
   EGRESADO = "EGRESADO",
   ADMINISTRADOR = "ADMINISTRADOR"
+}
+
+export const APP_ROUTES = {
+  tabs: {
+    destacados: '/tabs/destacados',
+    candidatos: '/tabs/candidatos-destacados'
+  }
 }

--- a/src/app/shared/interfaces/egresado.interface.ts
+++ b/src/app/shared/interfaces/egresado.interface.ts
@@ -13,6 +13,7 @@ export interface Egresado {
   profilePicUrl?: string;
   about?: string;
   destacado?: boolean;
+  fueDestacado?: boolean;
   descripcionDestacado?: string;
   Activo?: boolean;
   // Nacionalidad

--- a/src/app/shared/services/RouterExt.service.ts
+++ b/src/app/shared/services/RouterExt.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+
+@Injectable()
+export class RouterExtService {
+  
+  private previousUrl: string = undefined;
+  private currentUrl: string = undefined;
+
+  constructor(private router : Router) {
+    this.currentUrl = this.router.url;
+    router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        this.previousUrl = this.currentUrl;
+        this.currentUrl = event.url;
+      };
+    });
+  }
+
+  public getPreviousUrl(){
+    return this.previousUrl;
+  }    
+}

--- a/src/app/shared/services/egresados.service.ts
+++ b/src/app/shared/services/egresados.service.ts
@@ -78,8 +78,8 @@ export class EgresadosService {
     }
   }
 
-  updateEgresadoStatus(egresadoId: number, status: boolean): Observable<Egresado> {
-    return this.http.patch<Egresado>(`${this.JSON_SERVER_URL}/egresado/${egresadoId}`, { Activo: status });
+  updateEgresadoStatus(egresadoId: number, update: Record<string, any>): Observable<Egresado> {
+    return this.http.patch<Egresado>(`${this.JSON_SERVER_URL}/egresado/${egresadoId}`, update);
   }
 
   filterEgresados(egresadosFilters: egresadosFilters, page?: number, q: any = undefined): Observable<Egresado[]> {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,6 +11,7 @@ import { LoaderComponentModule } from './components/loader/loader.module';
 import { NgxMaskDirective, NgxMaskPipe, provideNgxMask } from 'ngx-mask';
 
 import { PhoneMaskDirective } from './phone-mask.directive';
+import { RouterExtService } from './services/RouterExt.service';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { PhoneMaskDirective } from './phone-mask.directive';
     EgresadosService,
     HelperService,
     EntitiesService,
+    RouterExtService,
     provideNgxMask()
   ]
 })


### PR DESCRIPTION
### Detalles

1. Se agregó un nuevo servicio para obtener la ruta previa, eso es útil para cargar siempre que se vengan de rutas que dependen de otras. (ionic cachea los tabs y no corre ngOnInit siempre)
2. Edición de la descripción de destacado
3. Marcar candidato como destacado.